### PR TITLE
Updated composer installer

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /php
 
 # Get composer: https://getcomposer.org/download/
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 RUN ln -s /php/composer.phar /usr/bin/composer


### PR DESCRIPTION
So docker will not error with: Installer corrupt error.
https://hub.docker.com/r/aurelijusb/docker/builds/bvxhcgrvmrygsr8fgnct5ny/
```
Step 5/19 : RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
---> Running in 342dbbaeb43b
Installer corrupt
Removing intermediate container 342dbbaeb43b
---> 3da6203830f8 Step 6/19 : RUN php composer-setup.php
---> Running in cf5b4f90a792
Could not open input file: composer-setup.php
```

Related: https://github.com/nfqakademija/docker/pull/8
