### PR TITLE
Upgrade mysql

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.6.36
+FROM mysql:5.7.24
 
 LABEL maintainer "Aurelijus Banelis <aurelijus@banelis.lt>"
 


### PR DESCRIPTION
Because default Symfony documentation is using mysql 5.7