### PR TITLE
Include curl extensions

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -11,15 +11,10 @@ RUN php composer-setup.php
 RUN php -r "unlink('composer-setup.php');"
 RUN ln -s /php/composer.phar /usr/bin/composer
 
-# Install dependencies
+# Install depenedencies and PHP extensions
 RUN apt-get update \
- && apt-get install -y git zip unzip \
- && rm -rf /var/lib/apt/lists/*
-
-# Install PHP extensions
-RUN apt-get update \
- && apt-get install -y libzip-dev bash-completion procps nano libicu-dev g++ libpng-dev \
- && docker-php-ext-install -j$(nproc) zip mysqli pdo_mysql intl calendar exif gd gettext pcntl sockets opcache \
+ && apt-get install -y libzip-dev bash-completion procps nano libicu-dev g++ libpng-dev libcurl4-gnutls-dev \
+ && docker-php-ext-install -j$(nproc) zip mysqli pdo_mysql intl calendar exif gd gettext pcntl sockets opcache curl \
  && rm -rf /var/lib/apt/lists/*
 
 # xDebug helpers (do not use this in real production)


### PR DESCRIPTION
It was excluded in PHP7.3 as a separate package.

Follow up for: https://github.com/nfqakademija/docker/pull/14